### PR TITLE
Unityのバージョン

### DIFF
--- a/.github/workflows/activation.yml
+++ b/.github/workflows/activation.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           # Unity プロジェクトのバージョンを指定する
           # ProjectSettings/ProjectVersion.txt に記載されているバージョンを入力すれば OK
-          unityVersion: 2020.3.9f1
+          unityVersion: 2021.3.9f1
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/webgl_build.yml
+++ b/.github/workflows/webgl_build.yml
@@ -24,7 +24,7 @@ jobs:
           # ref: https://docs.unity3d.com/ScriptReference/BuildTarget.html
           targetPlatform: WebGL
 
-          unityVersion: 2020.3.9f1
+          unityVersion: 2021.3.9f1
       # Builder で出力した WebGL ビルドを GitHub Pages にデプロイする
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.3

--- a/src/ProjectSettings/GraphicsSettings.asset
+++ b/src/ProjectSettings/GraphicsSettings.asset
@@ -61,7 +61,7 @@ GraphicsSettings:
   m_FogKeepExp: 1
   m_FogKeepExp2: 1
   m_AlbedoSwatchInfos: []
-  m_LightsUseLinearIntensity: 1
+  m_LightsUseLinearIntensity: 0
   m_LightsUseColorTemperature: 1
   m_DefaultRenderingLayerMask: 1
   m_LogWhenShaderIsCompiled: 0

--- a/src/ProjectSettings/ProjectSettings.asset
+++ b/src/ProjectSettings/ProjectSettings.asset
@@ -47,7 +47,7 @@ PlayerSettings:
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
-  m_ActiveColorSpace: 1
+  m_ActiveColorSpace: 0
   m_MTRendering: 1
   mipStripping: 0
   numberOfMipsStripped: 0
@@ -521,6 +521,8 @@ PlayerSettings:
   m_BuildTargetGroupLightmapEncodingQuality:
   - m_BuildTarget: Android
     m_EncodingQuality: 1
+  - m_BuildTarget: WebGL
+    m_EncodingQuality: 1
   m_BuildTargetGroupLightmapSettings: []
   m_BuildTargetNormalMapEncoding:
   - m_BuildTarget: Android
@@ -770,7 +772,7 @@ PlayerSettings:
   webGLTemplate: APPLICATION:Default
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
-  webGLCompressionFormat: 0
+  webGLCompressionFormat: 2
   webGLWasmArithmeticExceptions: 0
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0


### PR DESCRIPTION
Unityのバージョンがプロジェクトの方が2021.3.9.f1なのに、ymlファイルで指定されているのが2020.3.9.f1でした。アクティベーションしなおして、UNITY_LICENSE のシークレットを取り直してください。
また、WebGLの設定がされていなかったので、これらを反映させてください。